### PR TITLE
A few small fixes

### DIFF
--- a/myco/include/config.h
+++ b/myco/include/config.h
@@ -3,15 +3,15 @@
 
 // Build configuration macros
 #ifdef NDEBUG
-    #define MYCO_RELEASE 1
-    #define MYCO_DEBUG 0
+    #define MYCO_RELEASE TRUE
+    #define MYCO_DEBUG FALSE
 #else
-    #define MYCO_RELEASE 0
-    #define MYCO_DEBUG 1
+    #define MYCO_RELEASE FALSE
+    #define MYCO_DEBUG TRUE
 #endif
 
 // Performance optimization macros
-#ifdef MYCO_RELEASE
+#if MYCO_RELEASE
     // Release mode: maximum performance, minimal size
     #define DEBUG_PRINT(fmt, ...) ((void)0)
     #define DEBUG_MEMORY_TRACKING 0

--- a/myco/src/loop_manager.c
+++ b/myco/src/loop_manager.c
@@ -30,6 +30,7 @@
  * - Cross-platform compatibility
  */
 
+#define _POSIX_C_SOURCE 200809L
 #include "loop_manager.h"
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
- Added POSIX standard macro definition to `loop_manager.h` to prevent `strdup` from being implicitly allocated
- Fixed preprocessor logic in `config.h` to enable debugging when dev build

Myco now compiles under Debian and is able to run `tests/test.myco`.